### PR TITLE
Team Carousel

### DIFF
--- a/layouts/partials/team.html
+++ b/layouts/partials/team.html
@@ -1,24 +1,22 @@
 {{ if gt (len .Site.Data.team) 0 }}
 <div class="team-container">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <ul class="owl-carousel testimonials">
-                    {{ range .Site.Data.team }}
-                    <li class="item team" title="{{ .name }}">
-                        {{ if .url }}
-                        <a href="{{ .url }}" target="_blank">
-                            <img src="{{ .image }}" alt="{{ .name }}" class="img-responsive" />
-                        </a>
-                        <h3>{{ .name }}</h3>
-                        <p class="team-caption">{{ .text}}</p>                        
-                        {{ else }}
-                        <img src="{{ .image }}" alt="{{ .name }}" class="img-responsive" /> {{ end }}
-                    </li>
-                    {{ end }}
-                </ul>
-                <!-- /.owl-carousel -->
-            </div>
+    <div class="row">
+        <div class="col-md-12">
+            <ul class="owl-carousel testimonials">
+                {{ range .Site.Data.team }}
+                <li class="item team" title="{{ .name }}">
+                    {{ if .url }}
+                    <a href="{{ .url }}" target="_blank">
+                        <img src="{{ .image }}" alt="{{ .name }}" class="img-responsive" />
+                    </a>
+                    <h3>{{ .name }}</h3>
+                    <p class="team-caption">{{ .text}}</p>                        
+                    {{ else }}
+                    <img src="{{ .image }}" alt="{{ .name }}" class="img-responsive" /> {{ end }}
+                </li>
+                {{ end }}
+            </ul>
+            <!-- /.owl-carousel -->
         </div>
     </div>
 </div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -513,9 +513,31 @@ li a i {
     margin: 0 auto !important;
 }
 
-.testimonials .item {
-    padding: 10px;
+.testimonials {
+    display: flex;
+    flex-wrap: wrap;
 }
+
+.testimonials .item {
+    width: 100%;
+    padding: 10px;
+    background: none;
+    margin: 0;
+    text-align: center;
+}
+
+@media(min-width: 480px) {
+    .testimonials .item {
+        width: 50%;
+    }
+}
+
+@media(min-width: 768px) {
+    .testimonials .item {
+        width: 33%;
+    }
+}
+
 .team-caption {
     font-size: 1em;
 }
@@ -523,8 +545,9 @@ li a i {
 .owl-item {
     text-align: center;
 }
-.testimonials .item {
-    background: none;
+
+.owl-item > .item {
+    width: 100%;
 }
 
 .testimonials .item img {

--- a/static/js/front.js
+++ b/static/js/front.js
@@ -22,6 +22,20 @@ $(function () {
   contactForm()
 })
 
+var options = {
+  desktopBreakpoint: 768
+}
+
+var state = {
+  isMobile: false
+}
+
+function detectViewport() {
+  return state.isMobile = window.innerWidth < options.desktopBreakpoint
+}
+
+window.addEventListener('resize', detectViewport)
+
 // Ajax contact
 function contactForm () {
   var form = $('.contact-form')
@@ -100,12 +114,16 @@ function sliders () {
       itemsMobile: [480, 1]
     })
 
-    $('.testimonials').owlCarousel({
-      items: 4,
-      itemsDesktopSmall: [990, 3],
-      itemsTablet: [768, 2],
-      itemsMobile: [480, 1]
-    })
+    if (state.isMobile) {
+      $('.testimonials').owlCarousel({
+        items: 4,
+        itemsDesktopSmall: [990, 3],
+        itemsTablet: [768, 2],
+        itemsMobile: [480, 1]
+      })
+    } else {
+      $('.testimonials').trigger('destroy.owl.carousel')
+    }
 
     $('.project').owlCarousel({
       navigation: true, // Show next and prev buttons

--- a/static/js/front.js
+++ b/static/js/front.js
@@ -8,7 +8,16 @@ if ($.cookie('themeLayout')) {
   $('body').addClass($.cookie('themeLayout'))
 }
 
+var options = {
+  tabletBreakpoint: 480
+}
+
+var state = {
+  isMobile: null
+}
+
 $(function () {
+  detectViewport()
   sliderHomepage()
   sliders()
   fullScreenContainer()
@@ -22,19 +31,10 @@ $(function () {
   contactForm()
 })
 
-var options = {
-  desktopBreakpoint: 768
-}
-
-var state = {
-  isMobile: false
-}
-
 function detectViewport() {
-  return state.isMobile = window.innerWidth < options.desktopBreakpoint
+  return state.isMobile = window.innerWidth < options.tabletBreakpoint
 }
 
-window.addEventListener('resize', detectViewport)
 
 // Ajax contact
 function contactForm () {
@@ -122,7 +122,9 @@ function sliders () {
         itemsMobile: [480, 1]
       })
     } else {
-      $('.testimonials').trigger('destroy.owl.carousel')
+      $('.testimonials')
+        .trigger('destroy.owl.carousel')
+        .removeClass('owl-carousel')
     }
 
     $('.project').owlCarousel({


### PR DESCRIPTION
**What's been changed**

1. Carousel only initiates on viewports below `480px`
If the page loads on a screen size below `480px`, the team items will be displayed in a carousel. If anything above, it will wrap.

Mobile:
![screen shot 2017-09-19 at 22 58 11](https://user-images.githubusercontent.com/6377078/30618124-f8fa6f08-9d90-11e7-9764-fbf574ad04e8.png)

Desktop:
![screen shot 2017-09-19 at 22 57 31](https://user-images.githubusercontent.com/6377078/30618123-f8f0d3ee-9d90-11e7-967f-eca67d5d3798.png)

If you load the page on a smaller viewport and increase the viewport size (by resizing browser, or changing device orientation for example), the initial load style will persist. For example, if you load the site in a browser at full width, then resize to a smaller width, it won't turn into a carousel, but items will remain responsive. Same goes for the opposite direction.

I felt that this approach would be more performant than constantly running a function on resize to check the viewport and width and then initiate/destroy the carousel instance based on that. This way, you get the full experience of each.

2. Remove `div .container` from the `team` partial
This was giving the team section an explicit width which was causing it to be cut off on some breakpoints.