### PR TITLE
Lessen the hit of fouc

### DIFF
--- a/layouts/partials/sponsors.html
+++ b/layouts/partials/sponsors.html
@@ -4,7 +4,7 @@
             <div class="col-md-12">
                 <ul class="sponsors customers">
                     {{ range .Site.Data.sponsors }}
-                    <li class="item" title="{{ .name }}">
+                    <li class="item sponsors-item" title="{{ .name }}">
                         {{ if .url }}
                         <a href="{{ .url }}" target="_blank">
                             <img src="{{ .image }}" alt="{{ .name }}" class="img-responsive" />
@@ -29,7 +29,7 @@
             <div class="col-md-12">
                 <ul class="sponsors customers">
                     {{ range .Site.Data.supporters }}
-                    <li class="item" title="{{ .name }}">
+                    <li class="item sponsors-item" title="{{ .name }}">
                         {{ if .url }}
                         <a href="{{ .url }}" target="_blank">
                             <img src="{{ .image }}" alt="{{ .name }}" class="img-responsive" />

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -586,6 +586,11 @@ button.read-more:focus {
     margin: 50px 20px 0 0;
 }
 
+.sponsors-item {
+    display: inline-block;
+    max-width: 200px;
+}
+
  .sponsors li img {
     width: 100%;
 }


### PR DESCRIPTION
It seems this is being caused by Owl Carousel. Initiating an instance of `owlCarousel` applies the `owl-item` class and applies inline styles to each sponsor item. That flash is the javascript running that function.

I've added some default styles to the sponsor items so it's a little less noticeable. I think to fully address the issue we'd need to look into some performance stuff for the site and get the js loading quicker.

Maybe we look at that post launch and get this fix in for now?